### PR TITLE
Notícia da API Insurgente

### DIFF
--- a/content/news/20160130-API.md
+++ b/content/news/20160130-API.md
@@ -1,0 +1,7 @@
+## Anunciamos a API Insurgente
+
+Os órgãos públicos integrantes da administração direta dos Poderes Executivo, Legislativo, incluindo as Cortes de Contas, e Judiciário e do Ministério Público; os órgãos públicos integrantes da administração direta dos Poderes Executivo, Legislativo, incluindo as Cortes de Contas, e Judiciário e do Ministério Público; entidades privadas sem fins lucrativos que recebam, para realização de ações de interesse público, recursos públicos diretamente do orçamento ou mediante subvenções sociais, contrato de gestão, termo de parceria, convênios, acordo, ajustes ou outros instrumentos congêneres. Chegou a hora em que iremos fazer vale o direito ao acesso a informação.
+
+Cansamos da falta sensação de que os dados estão disponíveis para todos.
+
+Conheçam o API Pirata: https://github.com/piratas/gti


### PR DESCRIPTION
## Notícia da API Pirata

Prezados, gostaria de bater a várias mãos o texto da API insurgente. O objetivo é abrir os olhos do governo sobre a importância de se modernizar e se eles não fizerem isso, os Piratas farão. Chega de mentir dizendo que o Brasil tem os dados abertos.

Fontes
----
www.weforum.org/agenda/2016/01/data-will-only-get-us-so-far-we-need-it-to-be-open
https://github.com/piratas/api-insurgente